### PR TITLE
fix: Specify the icon tint for all buttons

### DIFF
--- a/buttons/src/main/res/values/styles-buttons.xml
+++ b/buttons/src/main/res/values/styles-buttons.xml
@@ -46,6 +46,7 @@
         <item name="backgroundTint">@color/vtmn_btn_secondary_states</item>
         <item name="android:textColor">@color/vtmn_btn_secondary_text</item>
         <item name="strokeColor">@color/vtmn_btn_secondary_text</item>
+        <item name="iconTint">@color/vtmn_btn_secondary_text</item>
         <item name="rippleColor">@color/vtmn_btn_secondary_ripple</item>
         <item name="strokeWidth">2dp</item>
     </style>
@@ -60,11 +61,13 @@
 
     <style name="Widget.Vitamin.Button.Ghost" parent="@style/Widget.Vitamin.Button.TextButton">
         <item name="android:textColor">?attr/vtmnContentActive</item>
+        <item name="iconTint">?attr/vtmnContentActive</item>
         <item name="rippleColor">@color/vtmn_btn_ghost_ripple</item>
     </style>
 
     <style name="Widget.Vitamin.Button.Ghost.Reversed" parent="@style/Widget.Vitamin.Button.TextButton">
         <item name="android:textColor">?attr/vtmnContentPrimaryReversed</item>
+        <item name="iconTint">?attr/vtmnContentPrimaryReversed</item>
         <item name="rippleColor">@color/vtmn_btn_ghost_reversed_ripple</item>
     </style>
 </resources>


### PR DESCRIPTION
## Changes description 🧑‍💻
<!--- Describe your changes in detail -->
Specify icon tint for all buttons with the text color configuration

## Context 🤔
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Closes #33

## Checklist ✅
<!--- Feel free to add other steps if needed -->
 - [x] I have reviewed the submitted code
 - [x] I have tested on a phone device/emulator
 - [ ] I have tested on a tablet device/emulator
 - [ ] I have tested on a kiosk device/emulator

## Screenshots 📸

#### Phone
<!--- Put your phone screenshots here -->
![ezgif-2-0e9af7df9ee5](https://user-images.githubusercontent.com/1913901/131135137-f07503eb-62ca-4bce-a7ce-2e5a5ca3d06e.gif)
