### PR TITLE
fix: Use the good dimens for Body3 TextAppareance.

### DIFF
--- a/foundation/src/main/res/values/styles-texts.xml
+++ b/foundation/src/main/res/values/styles-texts.xml
@@ -104,8 +104,8 @@
     <style name="TextAppearance.Vitamin.Body3" parent="@style/TextAppearance.MaterialComponents.Body2">
         <item name="fontFamily">@font/roboto_regular</item>
         <item name="android:fontFamily">@font/roboto_regular</item>
-        <item name="android:textSize">@dimen/vtmn_text_size_body_2</item>
-        <item name="lineHeight">@dimen/vtmn_line_height_body_2</item>
+        <item name="android:textSize">@dimen/vtmn_text_size_body_3</item>
+        <item name="lineHeight">@dimen/vtmn_line_height_body_3</item>
         <item name="android:textStyle">normal</item>
         <item name="fontWeight">400</item>
         <item name="android:textColor">?attr/vtmnContentPrimary</item>


### PR DESCRIPTION
## Changes description 🧑‍💻
<!--- Describe your changes in detail -->
Use the good dimens for Body3 TextAppareance.

## Context 🤔
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Closes #48

## Checklist ✅
<!--- Feel free to add other steps if needed -->
 - [x] I have reviewed the submitted code
 - [x] I have tested on a phone device/emulator
 - [x] I have tested on a tablet device/emulator
 - [x] I have tested on a kiosk device/emulator