### PR TITLE
Fix dropdown styles and background color

### DIFF
--- a/foundation/foundation/src/main/res/values/styles.xml
+++ b/foundation/foundation/src/main/res/values/styles.xml
@@ -11,7 +11,7 @@
         <item name="colorOnSurface">?attr/vtmnContentPrimary</item>
         <item name="colorError">?attr/vtmnContentNegative</item>
         <item name="colorOnError">?attr/vtmnContentPrimaryReversed</item>
-        <item name="android:windowBackground">?attr/vtmnBackgroundPrimary</item>
+        <item name="android:windowBackground">?attr/vtmnBackgroundSecondary</item>
         <item name="colorControlActivated">?attr/colorSecondary</item>
 
         <!-- Typographies -->

--- a/menus/README.md
+++ b/menus/README.md
@@ -76,7 +76,7 @@ implementation("com.decathlon.vitamin:menus:<version>")
         ...
         <item name="android:spinnerDropDownItemStyle">?attr/vtmnDropDownItemStyle</item>
         <item name="spinnerDropDownItemStyle">?attr/vtmnDropDownItemStyle</item>
-        <item name="vtmnDropDownItemStyle">@style/Widget.Vitamin.Dropdown</item>
+        <item name="vtmnDropDownItemStyle">@style/Widget.Vitamin.Dropdown.Text</item>
         <item name="popupMenuStyle">@style/Widget.Vitamin.Menu</item>
         <item name="listPopupWindowStyle">@style/Widget.Vitamin.Menu.List</item>
     </style>

--- a/vitamin/src/main/res/values/styles.xml
+++ b/vitamin/src/main/res/values/styles.xml
@@ -59,7 +59,7 @@
         <!-- Menu -->
         <item name="android:spinnerDropDownItemStyle">?attr/vtmnDropDownItemStyle</item>
         <item name="spinnerDropDownItemStyle">?attr/vtmnDropDownItemStyle</item>
-        <item name="vtmnDropDownItemStyle">@style/Widget.Vitamin.Dropdown</item>
+        <item name="vtmnDropDownItemStyle">@style/Widget.Vitamin.Dropdown.Text</item>
         <item name="popupMenuStyle">@style/Widget.Vitamin.Menu</item>
         <item name="listPopupWindowStyle">@style/Widget.Vitamin.Menu.List</item>
     </style>


### PR DESCRIPTION
## Changes description 🧑‍💻
<!--- Describe your changes in detail -->
* Use the correct dropdown style for vtmnDropDownItemStyle.
* Migrate windowBackground to vtmnBackgroundSecondary color.

## Context 🤔
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
No issue for that but should be merged before the release 0.2.0.

## Checklist ✅
<!--- Feel free to add other steps if needed -->
 - [x] I have reviewed the submitted code
 - [x] I have tested on a phone device/emulator
 - [x] I have tested on a tablet device/emulator
 - [x] I have tested on a kiosk device/emulator

## Screenshots 📸

#### Phone
<!--- Put your phone screenshots here -->
<img width="300" src="https://user-images.githubusercontent.com/1913901/148388894-eaaf14ae-0046-4b7c-9ecb-a9a4fcd8938b.png"> <img width="300" src="https://user-images.githubusercontent.com/1913901/148388874-e857c6d9-ce8f-4756-8973-612f9045781e.png">

#### Tablet
<!--- Put your tablet screenshots here -->
<img height="500" src="https://user-images.githubusercontent.com/1913901/148389174-0c83f269-84bf-4721-a8ea-d117169c87ab.png">
<img height="500" src="https://user-images.githubusercontent.com/1913901/148389327-1e0cf9ee-4143-4702-b514-3e3ee3510332.png">

#### Kiosk
<!--- Put your kiosk screenshots here -->
<img height="500" src="https://user-images.githubusercontent.com/1913901/148389390-24610e7d-e010-4416-88d3-5d5c477d4ec3.png">
<img height="500" src="https://user-images.githubusercontent.com/1913901/148389414-b84212fa-b4e5-42b5-8216-fe0b2329967d.png">
