### PR TITLE
fix: change paint flags to SpannableString in strikethrough prices

### DIFF
--- a/foundation/foundation/src/main/java/fondation/extensions/Extensions.kt
+++ b/foundation/foundation/src/main/java/fondation/extensions/Extensions.kt
@@ -1,0 +1,10 @@
+package fondation.extensions
+
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.StrikethroughSpan
+
+fun SpannableString.setStrikethrough() : SpannableString {
+    this.setSpan(StrikethroughSpan(), 0, this.length, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
+    return this
+}

--- a/prices/src/main/java/com/decathlon/vitamin/prices/VitaminPrices.kt
+++ b/prices/src/main/java/com/decathlon/vitamin/prices/VitaminPrices.kt
@@ -2,11 +2,9 @@ package com.decathlon.vitamin.prices
 
 import android.content.Context
 import android.text.SpannableString
-import android.text.Spanned
-import android.text.style.StrikethroughSpan
 import android.util.AttributeSet
 import com.google.android.material.textview.MaterialTextView
-
+import fondation.extensions.setStrikethrough
 
 open class VitaminPriceDefaultSmall @JvmOverloads constructor(
     context: Context,
@@ -68,9 +66,7 @@ open class VitaminPriceStrikethroughSmall @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.priceStrikethroughSmall
 ) : MaterialTextView(context, attrs, defStyleAttr) {
     init {
-        val string = SpannableString(this.text)
-        string.setSpan(StrikethroughSpan(), 0, string.length, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-        this.text = string
+        this.text = SpannableString(this.text).setStrikethrough()
     }
 }
 
@@ -80,9 +76,7 @@ open class VitaminPriceStrikethroughMedium @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.priceStrikethroughMedium
 ) : MaterialTextView(context, attrs, defStyleAttr) {
     init {
-        val string = SpannableString(this.text)
-        string.setSpan(StrikethroughSpan(), 0, string.length, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-        this.text = string
+        this.text = SpannableString(this.text).setStrikethrough()
     }
 }
 
@@ -92,8 +86,6 @@ open class VitaminPriceStrikethroughLarge @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.priceStrikethroughLarge
 ) : MaterialTextView(context, attrs, defStyleAttr) {
     init {
-        val string = SpannableString(this.text)
-        string.setSpan(StrikethroughSpan(), 0, string.length, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-        this.text = string
+        this.text = SpannableString(this.text).setStrikethrough()
     }
 }

--- a/prices/src/main/java/com/decathlon/vitamin/prices/VitaminPrices.kt
+++ b/prices/src/main/java/com/decathlon/vitamin/prices/VitaminPrices.kt
@@ -1,7 +1,9 @@
 package com.decathlon.vitamin.prices
 
 import android.content.Context
-import android.graphics.Paint
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.StrikethroughSpan
 import android.util.AttributeSet
 import com.google.android.material.textview.MaterialTextView
 
@@ -66,7 +68,9 @@ open class VitaminPriceStrikethroughSmall @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.priceStrikethroughSmall
 ) : MaterialTextView(context, attrs, defStyleAttr) {
     init {
-        this.paintFlags = Paint.STRIKE_THRU_TEXT_FLAG
+        val string = SpannableString(this.text)
+        string.setSpan(StrikethroughSpan(), 0, string.length, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
+        this.text = string
     }
 }
 
@@ -76,7 +80,9 @@ open class VitaminPriceStrikethroughMedium @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.priceStrikethroughMedium
 ) : MaterialTextView(context, attrs, defStyleAttr) {
     init {
-        this.paintFlags = Paint.STRIKE_THRU_TEXT_FLAG
+        val string = SpannableString(this.text)
+        string.setSpan(StrikethroughSpan(), 0, string.length, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
+        this.text = string
     }
 }
 
@@ -86,6 +92,8 @@ open class VitaminPriceStrikethroughLarge @JvmOverloads constructor(
     defStyleAttr: Int = R.attr.priceStrikethroughLarge
 ) : MaterialTextView(context, attrs, defStyleAttr) {
     init {
-        this.paintFlags = Paint.STRIKE_THRU_TEXT_FLAG
+        val string = SpannableString(this.text)
+        string.setSpan(StrikethroughSpan(), 0, string.length, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
+        this.text = string
     }
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Change paint flag to SpannableString to have clear text on strikethrough price

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
Closes #111 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [X] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [X] Check your code additions will fail neither code linting checks.
- [X] I have reviewed the submitted code.
- [X] I have tested on a phone device/emulator.
- [X] I have tested on a tablet device/emulator.
- [X] I have tested on a large screen device/emulator.
- [X] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
- No

## Screenshots
Before : 
![image](https://user-images.githubusercontent.com/54030002/161939531-6d871479-ea13-4a46-bd9c-bd34ecf06aaf.png)
After : 
![image](https://user-images.githubusercontent.com/54030002/161941011-2d0aaec6-384c-451d-aa53-b63f3dd2957d.png)


## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
