### PR TITLE
fix: strikethrough price whenever text is set

### DIFF
--- a/prices/src/main/java/com/decathlon/vitamin/prices/VitaminPrices.kt
+++ b/prices/src/main/java/com/decathlon/vitamin/prices/VitaminPrices.kt
@@ -65,8 +65,8 @@ open class VitaminPriceStrikethroughSmall @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.vtmnPriceStrikethroughSmallStyle
 ) : MaterialTextView(context, attrs, defStyleAttr) {
-    init {
-        this.text = SpannableString(this.text).setStrikethrough()
+    override fun setText(text: CharSequence?, type: BufferType?) {
+        super.setText(SpannableString(text).setStrikethrough(), type)
     }
 }
 
@@ -75,8 +75,8 @@ open class VitaminPriceStrikethroughMedium @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.vtmnPriceStrikethroughMediumStyle
 ) : MaterialTextView(context, attrs, defStyleAttr) {
-    init {
-        this.text = SpannableString(this.text).setStrikethrough()
+    override fun setText(text: CharSequence?, type: BufferType?) {
+        super.setText(SpannableString(text).setStrikethrough(), type)
     }
 }
 
@@ -85,7 +85,7 @@ open class VitaminPriceStrikethroughLarge @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.vtmnPriceStrikethroughLargeStyle
 ) : MaterialTextView(context, attrs, defStyleAttr) {
-    init {
-        this.text = SpannableString(this.text).setStrikethrough()
+    override fun setText(text: CharSequence?, type: BufferType?) {
+        super.setText(SpannableString(text).setStrikethrough(), type)
     }
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Make the spannable string in the setText(...) method instead of in the init to allow editing the text other than just in xml.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
closes #122 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [X] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [X] Check your code additions will fail neither code linting checks.
- [X] I have reviewed the submitted code.
- [X] I have tested on a phone device/emulator.
- [X] I have tested on a tablet device/emulator.
- [X] I have tested on a large screen device/emulator.
- [X] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
- No

## Screenshots

#### Phone
![Screenshot_2022-06-16-16-09-17-22_5718ac90fb9fac1e0ff66814035ae4fb](https://user-images.githubusercontent.com/54030002/174090203-d1ad65be-77ff-42cc-ac6c-f81c408a4d87.jpg)

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
I changed the sample to make : 
`binding.priceStrikethroughMedium.text = "250 €"` 
At first, the result was : 
![Screenshot_2022-06-16-16-08-20-47_5718ac90fb9fac1e0ff66814035ae4fb](https://user-images.githubusercontent.com/54030002/174090169-72a8ba6c-19fa-4aef-ac60-90255131c599.jpg)

And with the modification : 
![Screenshot_2022-06-16-16-09-17-22_5718ac90fb9fac1e0ff66814035ae4fb](https://user-images.githubusercontent.com/54030002/174090203-d1ad65be-77ff-42cc-ac6c-f81c408a4d87.jpg)
